### PR TITLE
add maxRetryDelay variable and apply it in the error catch retry logic

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -32,6 +32,7 @@ export class ElkM1Platform implements DynamicPlatformPlugin {
     private garageDoorAccessories: ElkGarageDoor[] = [];
 
     private initialRetryDelay = 5000;
+    private maxRetryDelay = 30000;
     private retryDelay = this.initialRetryDelay;
 
     constructor(
@@ -120,7 +121,8 @@ export class ElkM1Platform implements DynamicPlatformPlugin {
             setTimeout(() => {
                 this.connect();
             }, this.retryDelay);
-            this.retryDelay = this.retryDelay * 2;
+            // this.retryDelay = this.retryDelay * 2; will overflow the int after enough retries.  Use maxRetryDelay to cap the delay.
+            this.retryDelay = Math.min(this.retryDelay * 2, this.maxRetryDelay)
         });
 
         // When this event is fired it means Homebridge has restored all cached accessories from disk.


### PR DESCRIPTION
https://github.com/paulw11/homebridge-elkm1/issues/35

When trying to back-off on re-attempts, it increases the initial delay (5000ms) by 2x on each error. Unfortunately if the Elk is having an issue, it doesn't take long to exceed the size of an int variable and you start to get these errors in the log:

```
(node:157) TimeoutOverflowWarning: kube62 homebridge fit into a 32-bit signed integer. 
[11/4/2023, 5:59:54 PM] kube62 homebridge connecting to ElkM1 ETIMEDOUT. Will retry in Infinitys |  
Timeout duration kube62 homebridge 1.
```

The fix would be to cap it at about 30 seconds which is very reasonable for polling a local device in an error state.